### PR TITLE
fix(COCoroutine.m)  Fix batch await may not callback error.

### DIFF
--- a/Examples/coobjcBaseExample/coobjcBaseExampleTests/coobjcPromiseTests.m
+++ b/Examples/coobjcBaseExample/coobjcBaseExampleTests/coobjcPromiseTests.m
@@ -50,7 +50,7 @@ static id testPromise2() {
 static COPromise *testPromise11() {
     return [COPromise promise:^(COPromiseFullfill  _Nonnull fullfill, COPromiseReject  _Nonnull reject) {
         
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             fullfill(@"1");
         });
     }];
@@ -206,6 +206,7 @@ describe(@"Proimse tests", ^{
     });
     
     it(@"batch await test", ^{
+        __block NSInteger val = 0;
         co_launch(^{
             
             NSArray *results = batch_await(@[
@@ -213,6 +214,7 @@ describe(@"Proimse tests", ^{
                                              testPromise12(),
                                              testPromise13(),
                                              ]);
+            val = 1;
             expect(results[0]).to.equal(@"1");
             expect(results[1]).to.equal(@"2");
             expect(results[2]).to.equal([NSError errorWithDomain:@"aa" code:3 userInfo:@{}]);
@@ -221,6 +223,7 @@ describe(@"Proimse tests", ^{
         
         waitUntil(^(DoneCallback done) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(7 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                expect(val).to.equal(1);
                 done();
             });
         });

--- a/coobjc/api/COCoroutine.m
+++ b/coobjc/api/COCoroutine.m
@@ -383,7 +383,7 @@ NSArray *co_batch_await(NSArray * awaitableList) {
            
         } else if ([awaitable isKindOfClass:[COPromise class]]) {
             
-            COChan *chan = [COChan chan];
+            COChan *chan = [COChan chanWithBuffCount:1];
             COCoroutine *co = co_get_obj(t);
             
             COPromise *promise = awaitable;


### PR DESCRIPTION
### Summary

Fix batch await may not callback error.

batch await use Channel with no buffer.  Then send_nonblock may drop the value, so await will never callback.  Change to Channel with buffer count 1 can fix this problem.

### Other Information

Add unit test to check this situation.

