### PR TITLE
Feature/channel cancel

### DIFF
--- a/cocore/co_csp.h
+++ b/cocore/co_csp.h
@@ -33,6 +33,13 @@ typedef enum {
     CHANNEL_RECEIVE,
 } channel_op;
 
+enum channel_errorno {
+    CHANNEL_ALT_SUCCESS = 1,
+    CHANNEL_ALT_ERROR_COPYFAIL    = 0,
+    CHANNEL_ALT_ERROR_CANCELLED   = -1,     // cancel the current alt.
+    CHANNEL_ALT_ERROR_BUFFER_FULL = -2,     // no buffer remain, send_nonblock fail
+    CHANNEL_ALT_ERROR_NO_VALUE    = -3,     // receive_nonblock fail
+};
 
 typedef struct chan_alt chan_alt;
 typedef struct chan_queue chan_queue;
@@ -109,7 +116,7 @@ void chanfree(co_channel *chan);
 
  @param c channel
  @param v the pointer will store received value.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int channbrecv(co_channel *c, void *v);
 
@@ -117,7 +124,7 @@ int channbrecv(co_channel *c, void *v);
  Non-blocking receive a pointer value from channel.
 
  @param c channel
- @return received pointer value.
+ @return received pointer value, default NULL.
  */
 void *channbrecvp(co_channel *c);
 
@@ -125,7 +132,7 @@ void *channbrecvp(co_channel *c);
  Non-blocking receive a unsigned long value from channel.
 
  @param c channel
- @return received unsigned long value.
+ @return received unsigned long value, default 0.
  */
 unsigned long channbrecvul(co_channel *c);
 
@@ -134,7 +141,7 @@ unsigned long channbrecvul(co_channel *c);
 
  @param c channel
  @param v the value's address.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int channbsend(co_channel *c, void *v);
 
@@ -143,7 +150,7 @@ int channbsend(co_channel *c, void *v);
 
  @param c channel
  @param v the pointer
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int channbsendp(co_channel *c, void *v);
 
@@ -152,7 +159,7 @@ int channbsendp(co_channel *c, void *v);
  
  @param c channel
  @param v the unsigned long value
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int channbsendul(co_channel *c, unsigned long v);
 
@@ -163,7 +170,7 @@ int channbsendul(co_channel *c, unsigned long v);
  
  @param c channel
  @param v the pointer will store received value.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chanrecv(co_channel *c, void *v);
 
@@ -173,7 +180,7 @@ int chanrecv(co_channel *c, void *v);
  If no one sending, and buffer is empty, blocking the current coroutine.
  
  @param c channel
- @return received pointer.
+ @return received pointer, default NULL.
  */
 void *chanrecvp(co_channel *c);
 
@@ -183,7 +190,7 @@ void *chanrecvp(co_channel *c);
  If no one sending, and buffer is empty, blocking the current coroutine.
  
  @param c channel
- @return received unsigned long value.
+ @return received unsigned long value, default 0.
  */
 unsigned long chanrecvul(co_channel *c);
 
@@ -194,7 +201,7 @@ unsigned long chanrecvul(co_channel *c);
  
  @param c channel
  @param v the pointer will store received value.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chansend(co_channel *c, void *v);
 
@@ -203,7 +210,7 @@ int chansend(co_channel *c, void *v);
  
  @param c channel
  @param v the pointer
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chansendp(co_channel *c, void *v);
 
@@ -212,7 +219,7 @@ int chansendp(co_channel *c, void *v);
  
  @param c channel
  @param v the unsigned long value
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chansendul(co_channel *c, unsigned long v);
 
@@ -221,7 +228,7 @@ int chansendul(co_channel *c, unsigned long v);
  to cancel the blocking.
 
  @param co the coroutine object
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chan_cancel_alt_in_co(coroutine_t *co);
 
@@ -234,7 +241,7 @@ int chan_cancel_alt_in_co(coroutine_t *co);
  @param v the pointer pass the send value.
  @param exec  run at sending.
  @param cancelExec run at cancel a alt.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chansend_custom_exec(co_channel *c, void *v, IMP exec, IMP cancelExec);
 
@@ -244,7 +251,7 @@ int chansend_custom_exec(co_channel *c, void *v, IMP exec, IMP cancelExec);
  @param c channel
  @param v the value's address.
  @param exec  run at sending.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int channbsend_custom_exec(co_channel *c, void *v, IMP exec);
 
@@ -256,7 +263,7 @@ int channbsend_custom_exec(co_channel *c, void *v, IMP exec);
  @param c channel
  @param v the pointer will store received value.
  @param cancelExec run at cancel a alt.
- @return 1 success, else fail.
+ @return channel_errorno
  */
 int chanrecv_custom_exec(co_channel *c, void *v, IMP cancelExec);
 

--- a/cocore/co_csp.m
+++ b/cocore/co_csp.m
@@ -301,9 +301,6 @@ static int altcopy(chan_alt *s, chan_alt *r) {
     if(s && r){
         // no buffer
         if (c->buffer.count == 0) {
-            if (s->custom_exec) {
-                s->custom_exec();
-            }
             amove(r->value, s->value, c->buffer.elemsize);
             return 1;
         } else {

--- a/cocore/coroutine.h
+++ b/cocore/coroutine.h
@@ -50,13 +50,14 @@ extern "C" {
         void *stack_memory;                     // Coroutine's stack memory address.
         void *stack_top;                    // Coroutine's stack top address.
         struct coroutine_scheduler *scheduler;  // The pointer to the scheduler.
-        int8_t   is_scheduler;                  // The coroutine is a scheduler.
         
         struct coroutine *prev;
         struct coroutine *next;
         
         void *autoreleasepage;                  // If enable autorelease, the custom autoreleasepage.
+        void *chan_alt;                         // If blocking by a channel, record the alt
         bool is_cancelled;                      // The coroutine is cancelled
+        int8_t   is_scheduler;                  // The coroutine is a scheduler.
     };
     typedef struct coroutine coroutine_t;
     

--- a/coobjc.xcodeproj/project.pbxproj
+++ b/coobjc.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/coobjc/actor/COActorChan.m
+++ b/coobjc/actor/COActorChan.m
@@ -30,9 +30,6 @@
 @implementation COActorChan
 
 - (COActorMessage *)next {
-    if (self.isCancelled) {
-        return nil;
-    }
     id obj = [self receive];
     if (![obj isKindOfClass:[COActorMessage class]]) {
         self.lastMessage = nil;

--- a/coobjc/co/COChan.h
+++ b/coobjc/co/COChan.h
@@ -61,6 +61,7 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
 /**
  Send a value to the Channel.
  
+ @see send:onCancel:
  @discussion This method may blocking the current process, when there's no one receives and buffer is full.
  So, this method requires calling in a coroutine.
  
@@ -68,6 +69,14 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  */
 - (void)send:(Value _Nullable )val;
 
+/**
+ Send a value to the Channel.
+ 
+ Requires calling in a coroutine.
+ 
+ @param val the value send to Channel.
+ @param cancelBlock call back when the coroutine cancels.
+ */
 - (void)send:(Value _Nullable )val onCancel:(COChanOnCancelBlock _Nullable)cancelBlock;
 
 /**
@@ -79,7 +88,15 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  */
 - (Value _Nullable )receive;
 
-- (Value _Nullable )receiveWithOnCancel:(COChanOnCancelBlock _Nullable)cancelBlock;;
+/**
+ Receive a value from the Channel, blocking.
+ 
+ @see `receive`
+ 
+ @return the value received from the channel
+ @param cancelBlock call back when the coroutine cancels.
+ */
+- (Value _Nullable )receiveWithOnCancel:(COChanOnCancelBlock _Nullable)cancelBlock;
 
 /**
  Send a value to the Channel, non blocking.

--- a/coobjc/co/COChan.h
+++ b/coobjc/co/COChan.h
@@ -20,6 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class COCoroutine;
+
 /**
  The channel object.
  
@@ -128,17 +130,12 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  Sometimes, we need cancel a operation, such as a Network Connection. So, a coroutine is cancellable.
  But Channel may blocking the coroutine, so we need cancel the Channel when cancel a coroutine.
  */
-- (void)cancel;
+- (void)cancelForCoroutine:(COCoroutine *)co;
 
 /**
- tell us is the channel is cancelled.
-
- @return isCancelled.
- */
-- (BOOL)isCancelled;
-
-/**
- Set a callback block when the Channel is cancel.
+ Set a callback block when the Channel cancel current blocking operation(send: or receive:)
+ 
+ Must set before `send:` or `receive:`, or it will not work.
 
  @param onCancelBlock the cancel callback block.
  */

--- a/coobjc/co/COChan.h
+++ b/coobjc/co/COChan.h
@@ -68,6 +68,8 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  */
 - (void)send:(Value _Nullable )val;
 
+- (void)send:(Value _Nullable )val onCancel:(COChanOnCancelBlock _Nullable)cancelBlock;
+
 /**
  Receive a value from the Channel, blocking.
  
@@ -76,6 +78,8 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  @return the value received from the channel
  */
 - (Value _Nullable )receive;
+
+- (Value _Nullable )receiveWithOnCancel:(COChanOnCancelBlock _Nullable)cancelBlock;;
 
 /**
  Send a value to the Channel, non blocking.
@@ -132,14 +136,14 @@ typedef void (^COChanOnCancelBlock)(COChan *chan);
  */
 - (void)cancelForCoroutine:(COCoroutine *)co;
 
-/**
+/** @deprecated This method is not safe. use `send:onCancel:` or `receiveWithOnCancel:`
  Set a callback block when the Channel cancel current blocking operation(send: or receive:)
  
  Must set before `send:` or `receive:`, or it will not work.
 
  @param onCancelBlock the cancel callback block.
  */
-- (void)onCancel:(COChanOnCancelBlock _Nullable )onCancelBlock;
+// - (void)onCancel:(COChanOnCancelBlock _Nullable )onCancelBlock;
 
 @end
 

--- a/coobjc/co/COChan.m
+++ b/coobjc/co/COChan.m
@@ -136,7 +136,7 @@ static void co_chan_custom_resume(coroutine_t *co) {
     }
     co.currentChan = nil;
     
-    if (ret == 1) {
+    if (ret == CHANNEL_ALT_SUCCESS) {
         // success
         do {
             COOBJC_SCOPELOCK(_buffLock);
@@ -200,7 +200,7 @@ static void co_chan_custom_resume(coroutine_t *co) {
     uint8_t val = 0;
     int ret = channbrecv(_chan, &val);
 
-    if (ret == 1) {
+    if (ret == CHANNEL_ALT_SUCCESS) {
         
         do {
             COOBJC_SCOPELOCK(_buffLock);

--- a/coobjc/co/COCoroutine.h
+++ b/coobjc/co/COCoroutine.h
@@ -144,7 +144,7 @@ extern NSString *const COInvalidException;
  @param stackSize : stackSize of the coroutine.
  @return The coroutine object.
  */
-- (instancetype)initWithBlock:(void (^)(void))block onQueue:(dispatch_queue_t)queue stackSize:(NSUInteger)stackSize;
+- (instancetype)initWithBlock:(void (^)(void))block onQueue:(dispatch_queue_t _Nullable)queue stackSize:(NSUInteger)stackSize;
 
 /**
  The coroutine is Finished.

--- a/coobjc/co/COCoroutine.m
+++ b/coobjc/co/COCoroutine.m
@@ -176,15 +176,19 @@ static void co_obj_dispose(void *coObj) {
 }
 
 - (void)_internalCancel {
+    // dead
+    if (_co == nil) {
+        return;
+    }
     
     if (_isCancelled) {
         return;
     }
     NSArray *subroutines = self.subroutines.copy;;
     if (subroutines.count) {
-        [subroutines enumerateObjectsUsingBlock:^(COCoroutine * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-            [obj cancel];
-        }];
+        for (COCoroutine *subco in subroutines) {
+            [subco cancel];
+        }
     }
     
     _isCancelled = YES;
@@ -196,7 +200,7 @@ static void co_obj_dispose(void *coObj) {
     
     COChan *chan = self.currentChan;
     if (chan) {
-        [chan cancel];
+        [chan cancelForCoroutine:self];
     }
 }
 

--- a/coobjc/promise/COPromise.m
+++ b/coobjc/promise/COPromise.m
@@ -354,12 +354,12 @@ static void *COProgressObserverContext = &COProgressObserverContext;
 }
 
 - (void)fulfill:(id)value{
-    [self.progressChannel cancel];
+    [self.progressChannel send_nonblock:nil];
     [super fulfill:value];
 }
 
 - (void)reject:(NSError *)error{
-    [self.progressChannel cancel];
+    [self.progressChannel send_nonblock:nil];
     [super reject:error];
 }
 

--- a/coswift/Coroutine.swift
+++ b/coswift/Coroutine.swift
@@ -48,11 +48,11 @@ open class Coroutine {
     public var queue: DispatchQueue
     
     /// The c pointer to coroutine_t struct
-    private var co: UnsafeMutablePointer<coroutine_t>?
+    public var co: UnsafeMutablePointer<coroutine_t>?
     
     /// The closure to cancel the blocking Channel when Coroutine cancel.
     /// If a channel blocking this coroutine, should set this block.
-    public var chanCancelBlock: (() -> Void)?
+    public var chanCancelBlock: ((Coroutine) -> Void)?
     
     /// The lastError occurred in the Coroutine.
     public var lastError: Error?
@@ -195,7 +195,7 @@ open class Coroutine {
         
         self.co?.pointee.is_cancelled = true
         if let chanCancel = self.chanCancelBlock {
-            chanCancel();
+            chanCancel(self);
         }
     }
     

--- a/coswift/Errors.swift
+++ b/coswift/Errors.swift
@@ -27,6 +27,7 @@ public enum COError: String, LocalizedError {
     case generatorCancelled = "The generator is cancelled"
     case generatorClosed = "The generator is closed"
     case notGenerator = "The current coroutine is not a generator"
+    case chanReceiveFailUnknown = "Channel receive fails unknown"
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {

--- a/coswift/coswift.swift
+++ b/coswift/coswift.swift
@@ -64,11 +64,9 @@ public func await<T>(promise: Promise<T>) throws -> Resolution<T>  {
             }
         }
         
-        chan.onCancel = { (channel) in
+        return try chan.receive(onCancel: { (channel) in
             promise.cancel()
-        }
-        
-        return try chan.receive()
+        })
         
     } else {
         throw COError.invalidCoroutine
@@ -113,7 +111,6 @@ public var co_isActive: Bool {
     }
 }
 
-
 /// co_delay, pause current coroutine seconds.
 ///
 /// - Parameter seconds: paused time
@@ -131,11 +128,9 @@ public func co_delay(_ seconds: TimeInterval) throws {
     }
     timer.schedule(deadline: .now() + seconds, repeating: .never)
     
-    chan.onCancel = { _ in
-        timer.cancel()
-    }
-    
     timer.resume()
     
-    try _ = chan.receive()
+    try _ = chan.receive(onCancel: { (chan) in
+        timer.cancel()
+    })
 }

--- a/coswift/coswift.swift
+++ b/coswift/coswift.swift
@@ -130,7 +130,7 @@ public func co_delay(_ seconds: TimeInterval) throws {
     
     timer.resume()
     
-    try _ = chan.receive(onCancel: { (chan) in
+    try _ = chan.receive(onCancel: { _ in
         timer.cancel()
     })
 }


### PR DESCRIPTION
1. Channel cancellation problem

When a coroutine cancels,  If it is blocking by a channel, the channel's blocking should release.   

In previous versions,  -[COChan  cancel] will do this.  But, it's wrong, Channel shouldn't have a `cancel` method,  the cancel should be on it's job object: `chan_alt`.  So this pull request fix this.

Changes:
- remove  `-[COChan  cancel]`  and  `-[COChan onCancel:]`
- add `-[COChan cancelForCoroutine:]`, `send:onCancel:`, `receiveWithOnCancel:`

2. Fix bugs

If send fails in channel, the COChan's buffList should not append the object.

3. batch_await

Use subroutines to implement it.   So it can concurrent and cancels.
