### PR TITLE
fix(UIImagePickerController+Coroutine.h) fixes #93

### DIFF
--- a/cokit/cokit/UIKit/UIImagePickerController+Coroutine.h
+++ b/cokit/cokit/UIKit/UIImagePickerController+Coroutine.h
@@ -39,7 +39,7 @@
 
 @property(nonatomic, copy, readonly) NSDictionary* mediaMetadata;
 
-@property(nonatomic, strong, readonly) PHLivePhoto *livePhoto PHOTOS_AVAILABLE_IOS_TVOS(9_1, 10_0);
+@property(nonatomic, strong, readonly) PHLivePhoto *livePhoto API_AVAILABLE(ios(9.1), tvos(10));
 
 @property(nonatomic, strong, readonly) PHAsset *asset;
 


### PR DESCRIPTION
Fix: PHOTOS_AVAILABLE_IOS_TVOS was removed in Xcode 11

Adapt Xcode11: replace PHOTOS_AVAILABLE_IOS_TVOS(9_1, 10_0) with
API_AVAILABLE(ios(9.1), tvos(10))

### Summary

fixes #93 

> Adapt Xcode11

### Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
- [√] I read the [Contributor Guide](./CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [√] My PR includes tests for *all* changed/updated/fixed behaviors (See [Test Coverage]).
- [√] All existing and new tests are passing.
- [√] I updated/added relevant documentation (doc comments with `///`).
- [√] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [√] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [√] I signed the [CLA].
- [√] I am willing to follow-up on review comments in a timely manner.

Thanks for contributing to coobjc!